### PR TITLE
changed reply modal trigger to a class rather than an id for reusability

### DIFF
--- a/assets/javascript/homepage.js
+++ b/assets/javascript/homepage.js
@@ -26,20 +26,22 @@ $( document ).ready(function() {
     $(".dropdown-trigger").dropdown();
 })
 
+$(document).ready(function(){
+  $('select').formSelect();
+});
+
 //Create new post modal shows
 $("#makeAPost-btn").on("click", function(){
     console.log ("post btn clicked");
     $("#createAPost-modal").modal();
 })
 
-$("#reply-modal-btn").on("click", function(){
+$(".reply-modal-btn").on("click", function(){
     console.log ("post btn clicked");
     $("#reply-modal").modal();
 })
 
-  $(document).ready(function(){
-    $('select').formSelect();
-  });
+
 
 //this is the function the pushes the post info the the correct db category
 function pushPostToDatabase(){

--- a/assets/javascript/homepage.js
+++ b/assets/javascript/homepage.js
@@ -30,6 +30,10 @@ $(document).ready(function(){
   $('select').formSelect();
 });
 
+$(document).ready(function(){
+  $('.tooltipped').tooltip();
+});
+
 //Create new post modal shows
 $("#makeAPost-btn").on("click", function(){
     console.log ("post btn clicked");

--- a/homepage.html
+++ b/homepage.html
@@ -129,7 +129,7 @@
                               <input placeholder="Ex: Cpt_Splunky" id="post-username" type="text" class="validate">
                               <label for="first_name">Username</label>
                           </div>
-                          <div class="input-field col s10 offset-s1 m6">
+                          <div class="input-field col s10 offset-s1 m6" id="post-category">
                               <select class="indigo-text">
                                 <option  value="music-category">Music</option>
                                 <option class="indigo-text" value="book-category">Books</option>
@@ -194,7 +194,7 @@
 
  <!-- Modal Trigger -->
  <div id="modal1-button">
-    <a class="btn-floating waves-effect waves-red modal-trigger hoverable red" href="#createAPost-modal" id="makeAPost-btn"> 
+    <a class="btn-floating waves-effect waves-red modal-trigger hoverable tooltipped red" data-position="left" data-tooltip="Create a new Post" href="#createAPost-modal" id="makeAPost-btn"> 
       <i class="small material-icons">add</i></a>
   </div>
 

--- a/homepage.html
+++ b/homepage.html
@@ -47,6 +47,7 @@
 
   <div class="container">
     <div class="row">
+
       <div id="mainContent" class="col s12 m8 offset-s0 offset-m2">
         <!-- This is where all the activity around MOVIES will go. Hidden until click -->
         <div id="movies-activity-div" class="category-activity-div"></div>
@@ -78,7 +79,7 @@
           <div class="card-action">
             <span class="num-favories">55</span> &nbsp; <a href="#"><i class="tiny material-icons">favorite
               </i></a>
-              <a href="#reply-modal" class="reply modal-trigger" id="reply-modal-btn">Reply </a>
+              <a href="#reply-modal"  class="reply modal-trigger reply-modal-btn">Reply </a>
               <a href="#" class="view-replies">View Replies </a>
           </div>
           <div class="replies card-content white-text">
@@ -91,7 +92,7 @@
           <div class="card-action">
             <span class="num-favories">1</span> &nbsp; <a href="#"><i class="tiny material-icons">favorite
               </i></a>
-            <a href="#reply-modal" class="reply modal-trigger" id="reply-modal-btn">Reply </a>
+            <a href="#reply-modal" class="reply modal-trigger reply-modal-btn">Reply </a>
           </div>
         </div>
 
@@ -112,7 +113,7 @@
           <div class="card-action">
             <span class="num-favories">32</span> &nbsp; <a href="#"><i class="tiny material-icons">favorite
               </i></a>
-            <a href="#reply-modal" class="reply modal-trigger" id="reply-modal-btn">Reply </a>
+            <a href="#reply-modal" class="reply modal-trigger reply-modal-btn">Reply </a>
             <a href="#" class="view-replies">View Replies </a>
           </div>
 
@@ -168,32 +169,28 @@
                 <div class="modal-content">
                     <h4 class="center-align indigo-text bold">Reply to Post</h4>
                     <div class="row">
-                        <div class="input-field col m6 s10 offset-s1"> 
-                            <input placeholder="Ex: Cpt_Splunky" id="post-username" type="text" class="validate">
-                            <label for="first_name">Username</label>
-                        </div>
-                        <div class="input-field col s12">
-                            <h5 for="textarea1" class="center-align">Post:</h5>
-                            <textarea id="post-content" rows="20" cols="50"></textarea>
-                        </div>
+                          <div class="input-field col m6 s10 offset-s1"> 
+                              <input placeholder="Ex: Cpt_Splunky" id="post-username" type="text" class="validate">
+                              <label for="first_name">Username</label>
+                          </div>
+                          <div class="input-field col s12">
+                              <h5 for="textarea1" class="center-align">Post:</h5>
+                              <textarea id="post-content" rows="20" cols="50"></textarea>
+                          </div>
                      </div>
-                  <div class="modal-footer">
-                      <div class=row>
-                        <div class="col s12 center-align">
-                            <button href="#!" class="modal-close waves-effect waves-indigo btn-flat indigo">Cancel</button>
-                            <button type="button" href="#!" class="modal-close waves-effect waves-green btn-flat indigo" onclick="createReply()">Leave Reply</button>
-                        </div>
-                     </div>
-                  </div>
-                </div>
-          </div>
+                      <div class="modal-footer">
+                          <div class=row>
+                            <div class="col s12 center-align">
+                                <button href="#!" class="modal-close waves-effect waves-indigo btn-flat indigo">Cancel</button>
+                                <button type="button" href="#!" class="modal-close waves-effect waves-indigo btn-flat indigo" onclick="createReply()">Leave Reply</button>
+                            </div>
+                          </div>
+                      </div>
+                 </div>
+              </div>
+
       </div>
-
-
-
-
-  </div>
-  <!--Container-->
+  </div><!--Container-->
 
  <!-- Modal Trigger -->
  <div id="modal1-button">


### PR DESCRIPTION
Changed the code of the reply modal trigger to a class rather than an ID so that it could be used in every instance that users would want to leave a reply.
<img width="648" alt="Screen Shot 2019-10-16 at 10 25 20 AM" src="https://user-images.githubusercontent.com/51139840/66934296-e473bd00-efff-11e9-9e57-3c09f3225fd0.png">

I also moved around some of the homepage.js code so that all of the navigational elements would be together.
<img width="495" alt="Screen Shot 2019-10-16 at 10 25 03 AM" src="https://user-images.githubusercontent.com/51139840/66934396-079e6c80-f000-11e9-8468-3f5b20961b84.png">

